### PR TITLE
Fix broken example markup in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ If the queried domain name is offered from a waiting list, the response will loo
     "public_domain_status": "W",
     "status": 200
 }
+```
 
 Do note the special status: `W`.
 


### PR DESCRIPTION
The markdown markup of some code in the readme is missing its closing tags, leading to the next few sections and paragraphs being rendered wrong.

This PR fixes this.